### PR TITLE
IS-0001: use custom s3 client to get files

### DIFF
--- a/tap_universal_file/files.py
+++ b/tap_universal_file/files.py
@@ -6,8 +6,9 @@ import datetime
 import re
 import tempfile
 from functools import cached_property
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator
+
+from tap_universal_file.s3_client import S3FileSystem
 
 if TYPE_CHECKING:
     import logging
@@ -47,6 +48,9 @@ class FilesystemManager:
 
         if self.protocol == "file":
             return fsspec.filesystem("file")
+
+        if self.protocol == "s3":
+            return S3FileSystem(self.config)
 
         if caching_strategy == "once":
             # Creaing a filecache without specifying cache_storage location will cause

--- a/tap_universal_file/s3_client.py
+++ b/tap_universal_file/s3_client.py
@@ -1,0 +1,60 @@
+from typing import Any
+from urllib.parse import urlparse
+
+import boto3
+import fsspec
+
+
+class S3FileSystem:
+    """This is to overwrite the functionality of reading the files for S3."""
+    def __init__(self, config: dict[str, Any]) -> None:  # noqa: FA102
+        """Initialize a new S3FileManager instance.
+
+        Args:
+            config: Configuration
+        """
+        self.config: dict[str, Any] = config
+        self.client = boto3.client("s3")
+        fsconfig = {
+            "anon": False,
+            "key": config["AWS_ACCESS_KEY_ID"],
+            "secret": config["AWS_SECRET_ACCESS_KEY"],
+        }
+        o = urlparse(f's3://{config["filepath"]}', allow_fragments=False)
+        self.bucket = o.netloc
+        self.prefix = o.path.lstrip("/")
+        self.fs = fsspec.filesystem(
+            protocol="s3",
+            **fsconfig,
+        )
+
+    def find(self):  # noqa: ANN201
+        """Return as list of s3 objects.
+
+        Args:
+            path (str): S3 path
+
+        """
+        files = []
+        self.paginator = self.client.get_paginator("list_objects_v2")
+        pages = self.paginator.paginate(Bucket=self.bucket, Prefix=self.prefix)
+        for page in pages:
+            for obj in page["Contents"]:
+                files.append(obj)  # noqa: PERF402
+
+        return files
+
+    def info(self, file):  # noqa: ANN001, ANN201
+        """Return updated s3 file object which works with fsspec.
+
+        Args:
+            file (dict): file object
+        """
+        # adjust keys to work with fsspec
+        file["name"] = f"{self.bucket}/{file['Key']}"
+        file["type"] = "file"
+        file["size"] = file["Size"]
+        return file
+
+    def open(self, **args):  # noqa: ANN003, D102, ANN201
+        return self.fs.open(**args)


### PR DESCRIPTION
There is an issue where tap spend a lot of time to get the files from s3. This is due to we call s3 api twice using `s3fs` package.

1. Get all the files : https://github.com/colorimageapparel/tap-universal-file/blob/main/tap_universal_file/files.py#L100
2. Get file info : https://github.com/colorimageapparel/tap-universal-file/blob/main/tap_universal_file/files.py#L101

In this PR, I have created a custom class to use boto3 get above steps done in single step.